### PR TITLE
Fix flicker of font change when loading the page

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,2 +1,1 @@
-import "bootstrap/dist/css/bootstrap.css"
 import "./src/styles/global.scss"

--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -1,0 +1,6 @@
+$font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Lato", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+$headings-font-family: "Amatic SC", cursive;
+$h1-font-size: floor((26px * 2.6));
+$h2-font-size: floor((26px * 2.15));
+$h3-font-size: ceil((26px * 1.7));
+$h4-font-size: ceil((26px * 1.25));

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,7 +1,9 @@
+@import 'custom';
+@import "~bootstrap/scss/bootstrap";
+
 html { scroll-behavior: smooth; }
 
 body {
-  font-family: 'Lato', sans-serif;
   background-color: #EAC435;
   color: white;
 }
@@ -15,54 +17,8 @@ section {
   justify-content: center;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 { font-family: 'Amatic SC', cursive; }
-
 mark {
   padding: 0 0.2em;
   background-color: white;
   color: black;
-}
-
-/* Extra small devices */
-@media only screen and (max-width: 320px) {
-  h1 { font-size: 2.25em; }
-
-  h2 { font-size: 2em; }
-
-  h3 { font-size: 1.5em; }
-
-  h4 { font-size: 1.25em; }
-
-  p { font-size: 0.85em; }
-}
-
-/* Small devices */
-@media only screen and (min-width: 321px) {
-  h1 { font-size: 2.5em; }
-
-  h2 { font-size: 2.25em; }
-
-  h3 { font-size: 1.75em; }
-
-  h4 { font-size: 1.25em; }
-
-  p { font-size: 0.9em; }
-}
-
-/* Medium devices */
-@media only screen and (min-width: 768px) {
-  h1 { font-size: 4.5em; }
-
-  h2 { font-size: 3.5em; }
-
-  h3 { font-size: 2.25em; }
-
-  h4 { font-size: 1.5em; }
-
-  p { font-size: 1em; }
 }


### PR DESCRIPTION
### Context

Currently, when you load the website you can see the font change as a flicker. It goes from the default Bootstrap typography to the overwrite set in `global.scss`. This was because overwriting of the fonts set in Bootstrap was not configured correctly as suggested by the [Bootstrap docs](https://getbootstrap.com/docs/4.1/getting-started/webpack/).

### Changes proposed in this pull request

This PR creates a `src/styles/_custom.scss` which includes all the Boostrap variable overwrites such `$font-family-sans-serif` and heading sizes. As a result, Bootstrap is no longer imported in `gatsby-browser.js` and is instead imported in `src/styles/global.scss`.

### Guidance to review

N/A
