### PR TITLE
Add responsive font sizes through Bootstrap

### DIFF
--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -1,3 +1,4 @@
+$enable-responsive-font-sizes: true;
 $font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Lato", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 $headings-font-family: "Amatic SC", cursive;
 $h1-font-size: floor((26px * 2.6));


### PR DESCRIPTION
### Context

Currently, font sizes aren't responsive. They should be.

### Changes proposed in this pull request

This PR enables responsive font sizes through Bootstrap support of RSF - https://getbootstrap.com/docs/4.3/content/typography/#responsive-font-sizes.

### Screenshots

#### Before
![image](https://user-images.githubusercontent.com/42817036/69481338-55c93b80-0e08-11ea-8796-3e4e9b53f6f8.png)

#### After

![image](https://user-images.githubusercontent.com/42817036/69481326-42b66b80-0e08-11ea-935f-03725b3a6f26.png)

### Guidance to review

N/A
