### PR TITLE
Change Travis to use committer from GitHub when deploying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,6 @@ jobs:
         provider: script
         script: yarn run deploy
         skip_cleanup: true
+        committer_from_gh: true
         on:
           branch: release-v2


### PR DESCRIPTION
### Context

When deploying using Travis CI, commits are made by `Travis CI User`.

![image](https://user-images.githubusercontent.com/42817036/69481530-097efb00-0e0a-11ea-80e1-238d59997af0.png)

### Changes proposed in this pull request

This PR enables `committer_from_gh` in `.travis.yml` to hopefully change the user to the user who committed.

### Guidance to review

N/A
