### PR TITLE
Add contact me section and update copyright year to 2020

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "version": "0.1.0",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.27",
+    "@fortawesome/free-brands-svg-icons": "^5.12.1",
+    "@fortawesome/free-solid-svg-icons": "^5.12.1",
+    "@fortawesome/react-fontawesome": "^0.1.8",
     "bootstrap": "^4.3.1",
     "gatsby": "^2.17.10",
     "gatsby-image": "^2.2.30",

--- a/src/components/ContactMe/ContactMe.js
+++ b/src/components/ContactMe/ContactMe.js
@@ -1,0 +1,42 @@
+import React from "react"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faGithub } from "@fortawesome/free-brands-svg-icons"
+
+import "./ContactMe.scss"
+
+const ContactMe = () => (
+  <>
+    <section id="contact-me">
+      <div className="container text-center">
+        <div className="row">
+          <div className="col">
+            <img
+              src="/icons/icon-72x72.png"
+              className="img-fluid"
+              alt="Wen Ting Wang Icon"
+            />
+            <h4>
+              <b>Wen Ting Wang</b>
+              <br />
+              <small>Let's develop Tings together.</small>
+            </h4>
+            <a
+              href="https://github.com/chubberlisk"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Wen Ting Wang's GitHub Profile"
+              data-toggle="tooltip"
+              data-placement="top"
+              title="GitHub - Chubberlisk"
+              className="social-link"
+            >
+              <FontAwesomeIcon icon={faGithub} />
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </>
+)
+
+export default ContactMe

--- a/src/components/ContactMe/ContactMe.scss
+++ b/src/components/ContactMe/ContactMe.scss
@@ -1,0 +1,18 @@
+section#contact-me {
+  min-height: 15vh;
+  background-color: var(--info);
+}
+
+ul { padding: 0; }
+
+li { list-style: none; }
+
+a.social-link {
+  color: white;
+  font-size: xx-large;
+  text-align: center;
+}
+
+a.social-link:hover {
+  color: black;
+}

--- a/src/components/ContactMe/ContactMe.test.js
+++ b/src/components/ContactMe/ContactMe.test.js
@@ -1,0 +1,11 @@
+import React from "react"
+import renderer from "react-test-renderer"
+
+import ContactMe from "./ContactMe"
+
+describe("ContactMe", () => {
+  it("renders correctly", () => {
+    const tree = renderer.create(<ContactMe />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/components/ContactMe/__snapshots__/ContactMe.test.js.snap
+++ b/src/components/ContactMe/__snapshots__/ContactMe.test.js.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContactMe renders correctly 1`] = `
+<section
+  id="contact-me"
+>
+  <div
+    className="container text-center"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col"
+      >
+        <img
+          alt="Wen Ting Wang Icon"
+          className="img-fluid"
+          src="/icons/icon-72x72.png"
+        />
+        <h4>
+          <b>
+            Wen Ting Wang
+          </b>
+          <br />
+          <small>
+            Let's develop Tings together.
+          </small>
+        </h4>
+        <a
+          aria-label="Wen Ting Wang's GitHub Profile"
+          className="social-link"
+          data-placement="top"
+          data-toggle="tooltip"
+          href="https://github.com/chubberlisk"
+          rel="noopener noreferrer"
+          target="_blank"
+          title="GitHub - Chubberlisk"
+        >
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-github fa-w-16 "
+            data-icon="github"
+            data-prefix="fab"
+            focusable="false"
+            role="img"
+            style={Object {}}
+            viewBox="0 0 496 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
+`;

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -6,7 +6,7 @@ const Footer = () => (
   <>
     <footer className="text-center">
       <p id="copyright-text">
-        <small>© 2019 Copyright: Wen Ting Wang</small>
+        <small>© 2020 Copyright: Wen Ting Wang</small>
       </p>
     </footer>
   </>

--- a/src/components/Footer/__snapshots__/Footer.test.js.snap
+++ b/src/components/Footer/__snapshots__/Footer.test.js.snap
@@ -8,7 +8,7 @@ exports[`Footer renders correctly 1`] = `
     id="copyright-text"
   >
     <small>
-      © 2019 Copyright: Wen Ting Wang
+      © 2020 Copyright: Wen Ting Wang
     </small>
   </p>
 </footer>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,12 +2,14 @@ import React from "react"
 
 import SEO from "../components/SEO/SEO"
 import Landing from "../components/Landing/Landing"
+import ContactMe from "../components/ContactMe/ContactMe"
 import Footer from "../components/Footer/Footer"
 
 const IndexPage = () => (
   <>
     <SEO title="Home" />
     <Landing />
+    <ContactMe />
     <Footer />
   </>
 )

--- a/test/e2e/user-visits-home-page-spec.js
+++ b/test/e2e/user-visits-home-page-spec.js
@@ -17,7 +17,10 @@ describe("User visits home page", function() {
   }
 
   function andISeeTheSlogan() {
-    cy.get("section#contact-me").should("include.text", "Let's develop Tings together.")
+    cy.get("section#contact-me").should(
+      "include.text",
+      "Let's develop Tings together."
+    )
   }
 
   function andISeeTheGitHubLink() {
@@ -27,6 +30,6 @@ describe("User visits home page", function() {
   }
 
   function andISeeAFooter() {
-    cy.get("footer").should("include.text", "© 2019 Copyright: Wen Ting Wang")
+    cy.get("footer").should("include.text", "© 2020 Copyright: Wen Ting Wang")
   }
 })

--- a/test/e2e/user-visits-home-page-spec.js
+++ b/test/e2e/user-visits-home-page-spec.js
@@ -3,6 +3,8 @@ describe("User visits home page", function() {
     whenIVisitTheHomePage()
 
     thenISeeTheWelcomeText()
+    andISeeTheSlogan()
+    andISeeTheGitHubLink()
     andISeeAFooter()
   })
 
@@ -14,7 +16,17 @@ describe("User visits home page", function() {
     cy.get("#landing").should("include.text", "Hi there!")
   }
 
+  function andISeeTheSlogan() {
+    cy.get("section#contact-me").should("include.text", "Let's develop Tings together.")
+  }
+
+  function andISeeTheGitHubLink() {
+    cy.get("section#contact-me a")
+      .should("have.attr", "href")
+      .and("include", "https://github.com/chubberlisk")
+  }
+
   function andISeeAFooter() {
-    cy.get("footer").should("include.text", `© 2019 Copyright: Wen Ting Wang`)
+    cy.get("footer").should("include.text", "© 2019 Copyright: Wen Ting Wang")
   }
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,6 +808,39 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@fortawesome/fontawesome-common-types@^0.2.27":
+  version "0.2.27"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.27.tgz#19706345859fc46adf3684ed01d11b40903b87e9"
+  integrity sha512-97GaByGaXDGMkzcJX7VmR/jRJd8h1mfhtA7RsxDBN61GnWE/PPCZhOdwG/8OZYktiRUF0CvFOr+VgRkJrt6TWg==
+
+"@fortawesome/fontawesome-svg-core@^1.2.27":
+  version "1.2.27"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.27.tgz#e4db8e3be81a40988213507c3e3d0c158a6641a3"
+  integrity sha512-sOD3DKynocnHYpuw2sLPnTunDj7rLk91LYhi2axUYwuGe9cPCw7Bsu9EWtVdNJP+IYgTCZIbyARKXuy5K/nv+Q==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.27"
+
+"@fortawesome/free-brands-svg-icons@^5.12.1":
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.12.1.tgz#67977addd15e21e57aa1ed71cd2ddecdfaa88647"
+  integrity sha512-IYUYcgGsQuwiIHjRGfeSTCIQKUSZMb6FsV6mDj78K0D+YzGJkM4cvEBBUMHtnla5D2HCxncMI/9JX5YIk2GHeQ==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.27"
+
+"@fortawesome/free-solid-svg-icons@^5.12.1":
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.12.1.tgz#76b6f958a3471821ff146f8f955e6d7cfe87147c"
+  integrity sha512-k3MwRFFUhyL4cuCJSaHDA0YNYMELDXX0h8JKtWYxO5XD3Dn+maXOMrVAAiNGooUyM2v/wz/TOaM0jxYVKeXX7g==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.27"
+
+"@fortawesome/react-fontawesome@^0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.8.tgz#cb6d4dd3aeec45b6ff2d48c812317a6627618511"
+  integrity sha512-I5h9YQg/ePA3Br9ISS18fcwOYmzQYDSM1ftH03/8nHkiqIVHtUyQBw482+60dnzvlr82gHt3mGm+nDUp159FCw==
+  dependencies:
+    prop-types "^15.5.10"
+
 "@gatsbyjs/relay-compiler@2.0.0-printer-fix.4":
   version "2.0.0-printer-fix.4"
   resolved "https://registry.yarnpkg.com/@gatsbyjs/relay-compiler/-/relay-compiler-2.0.0-printer-fix.4.tgz#4b06aeb4f2ceea5878b5832a2ced1bff9abb62bd"


### PR DESCRIPTION
### Context

A link to my GitHub profile would be nice.

### Changes proposed in this pull request

This PR:

- adds `font-awesome` in order to use icons specifically GitHub in this instance
- adds a contact me section which includes the WTW logo, slogan and a link to GitHub 

### Before

![image](https://user-images.githubusercontent.com/42817036/75115006-e2c3a100-5652-11ea-9e58-448cbe52c45e.png)

### After

![image](https://user-images.githubusercontent.com/42817036/75115005-da6b6600-5652-11ea-8056-77c1768a9670.png)

### Guidance to review

N/A
