### PR TITLE
Update interests cards to have same height

### DIFF
--- a/src/components/AboutMe/AboutMe.js
+++ b/src/components/AboutMe/AboutMe.js
@@ -41,55 +41,49 @@ const AboutMe = () => (
       <h3>Interests</h3>
       <div className="row">
         <div className="col-6 col-md-4 col-xl">
-          <div className="card card-default">
+          <div className="card card-default h-100">
             <div className="card-body">
               <FontAwesomeIcon icon={faLaughSquint} size="lg" />
-              <br />
               Puns
             </div>
           </div>
         </div>
         <div className="col-6 col-md-4 col-xl">
-          <div className="card card-default">
+          <div className="card card-default h-100">
             <div className="card-body">
               <FontAwesomeIcon icon={faPaintBrush} size="lg" />
-              <br />
               Microsoft Paint
             </div>
           </div>
         </div>
         <div className="col-6 col-md-4 col-xl">
-          <div className="card card-default">
+          <div className="card card-default h-100">
             <div className="card-body">
               <FontAwesomeIcon icon={faPhotoVideo} size="lg" />
-              <br />
               Microsoft Photos
             </div>
           </div>
         </div>
         <div className="col-6 col-md-4 col-xl">
-          <div className="card card-default">
+          <div className="card card-default h-100">
             <div className="card-body">
               <FontAwesomeIcon icon={faGamepad} size="lg" />
-              <br />
               Gaming
             </div>
           </div>
         </div>
         <div className="col-6 col-md-4 col-xl">
-          <div className="card card-default">
+          <div className="card card-default h-100">
             <div className="card-body">
               <FontAwesomeIcon icon={faMusic} size="lg" />
-              <br />
               Ukulele
             </div>
           </div>
         </div>
         <div className="col-6 col-md-4 col-xl">
-          <div className="card card-default">
+          <div className="card card-default h-100">
             <div className="card-body">
               <FontAwesomeIcon icon={faFutbol} size="lg" />
-              <br />
               Football
             </div>
           </div>

--- a/src/components/AboutMe/AboutMe.scss
+++ b/src/components/AboutMe/AboutMe.scss
@@ -11,5 +11,12 @@ section#about-me {
     border-radius: 0;
   }
 
-  .card-body { padding: 1rem; }
+  .card-body {
+    padding: 1.5rem 1rem;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
 }

--- a/src/components/AboutMe/__snapshots__/AboutMe.test.js.snap
+++ b/src/components/AboutMe/__snapshots__/AboutMe.test.js.snap
@@ -42,7 +42,7 @@ exports[`AboutMe renders correctly 1`] = `
         className="col-6 col-md-4 col-xl"
       >
         <div
-          className="card card-default"
+          className="card card-default h-100"
         >
           <div
             className="card-body"
@@ -64,7 +64,6 @@ exports[`AboutMe renders correctly 1`] = `
                 style={Object {}}
               />
             </svg>
-            <br />
             Puns
           </div>
         </div>
@@ -73,7 +72,7 @@ exports[`AboutMe renders correctly 1`] = `
         className="col-6 col-md-4 col-xl"
       >
         <div
-          className="card card-default"
+          className="card card-default h-100"
         >
           <div
             className="card-body"
@@ -95,7 +94,6 @@ exports[`AboutMe renders correctly 1`] = `
                 style={Object {}}
               />
             </svg>
-            <br />
             Microsoft Paint
           </div>
         </div>
@@ -104,7 +102,7 @@ exports[`AboutMe renders correctly 1`] = `
         className="col-6 col-md-4 col-xl"
       >
         <div
-          className="card card-default"
+          className="card card-default h-100"
         >
           <div
             className="card-body"
@@ -126,7 +124,6 @@ exports[`AboutMe renders correctly 1`] = `
                 style={Object {}}
               />
             </svg>
-            <br />
             Microsoft Photos
           </div>
         </div>
@@ -135,7 +132,7 @@ exports[`AboutMe renders correctly 1`] = `
         className="col-6 col-md-4 col-xl"
       >
         <div
-          className="card card-default"
+          className="card card-default h-100"
         >
           <div
             className="card-body"
@@ -157,7 +154,6 @@ exports[`AboutMe renders correctly 1`] = `
                 style={Object {}}
               />
             </svg>
-            <br />
             Gaming
           </div>
         </div>
@@ -166,7 +162,7 @@ exports[`AboutMe renders correctly 1`] = `
         className="col-6 col-md-4 col-xl"
       >
         <div
-          className="card card-default"
+          className="card card-default h-100"
         >
           <div
             className="card-body"
@@ -188,7 +184,6 @@ exports[`AboutMe renders correctly 1`] = `
                 style={Object {}}
               />
             </svg>
-            <br />
             Ukulele
           </div>
         </div>
@@ -197,7 +192,7 @@ exports[`AboutMe renders correctly 1`] = `
         className="col-6 col-md-4 col-xl"
       >
         <div
-          className="card card-default"
+          className="card card-default h-100"
         >
           <div
             className="card-body"
@@ -219,7 +214,6 @@ exports[`AboutMe renders correctly 1`] = `
                 style={Object {}}
               />
             </svg>
-            <br />
             Football
           </div>
         </div>


### PR DESCRIPTION
## Context

When on a mobile size screen, the interests cards are all different heights.

## Changes proposed in this pull request

This PR updates the interests cards to be the same height.

### Screenshots

| Before | After |
|--------|-------|
|![image](https://user-images.githubusercontent.com/42817036/76704365-6a3f8580-66d0-11ea-83cb-932f8083f726.png)|![image](https://user-images.githubusercontent.com/42817036/76704688-a673e580-66d2-11ea-96c6-d1bc42be36d7.png)|

## Guidance to review

N/A

## Link to Trello card

https://trello.com/c/OFrjNyrp/56-i-want-to-add-an-about-me-section-to-my-personal-website-so-that-people-know-who-i-am
