### PR TITLE
Add link to go down a section

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gatsby-source-filesystem": "^2.1.35",
     "gatsby-transformer-remark": "^2.6.58",
     "gatsby-transformer-sharp": "^2.3.2",
+    "hover.css": "^2.3.2",
     "node-sass": "^4.13.1",
     "prop-types": "^15.7.2",
     "react": "^16.11.0",

--- a/src/components/AboutMe/AboutMe.js
+++ b/src/components/AboutMe/AboutMe.js
@@ -1,4 +1,5 @@
 import React from "react"
+import NextSection from "../NextSection/NextSection"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
   faPaintBrush,
@@ -12,85 +13,88 @@ import {
 import "./AboutMe.scss"
 
 const AboutMe = () => (
-  <section id="about-me">
-    <div className="container">
-      <h2>A bit about me</h2>
-      <p>
-        I’m a Software Engineer at{" "}
-        <a
-          href="https://madetech.com"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Made Tech
-        </a>
-        , after graduating from the{" "}
-        <a
-          href="https://madetech.com/careers/academy"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Academy
-        </a>{" "}
-        programme in 2019. I build software that makes our customers happy,
-        using Agile practices and techniques such as continuous delivery,
-        test-driven development and pair programming. More recently though, I’ve
-        been using Microsoft Paint and Photos to bring a little silliness into
-        the workplace.
-      </p>
-      <h3>Interests</h3>
-      <div className="row">
-        <div className="col-6 col-md-4 col-xl">
-          <div className="card card-default h-100">
-            <div className="card-body">
-              <FontAwesomeIcon icon={faLaughSquint} size="lg" />
-              Puns
+  <>
+    <section id="about-me">
+      <div className="container">
+        <h2>A bit about me</h2>
+        <p>
+          I’m a Software Engineer at{" "}
+          <a
+            href="https://madetech.com"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Made Tech
+          </a>
+          , after graduating from the{" "}
+          <a
+            href="https://madetech.com/careers/academy"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Academy
+          </a>{" "}
+          programme in 2019. I build software that makes our customers happy,
+          using Agile practices and techniques such as continuous delivery,
+          test-driven development and pair programming. More recently though,
+          I’ve been using Microsoft Paint and Photos to bring a little silliness
+          into the workplace.
+        </p>
+        <h3>Interests</h3>
+        <div className="row">
+          <div className="col-6 col-md-4 col-xl">
+            <div className="card card-default h-100">
+              <div className="card-body">
+                <FontAwesomeIcon icon={faLaughSquint} size="lg" />
+                Puns
+              </div>
             </div>
           </div>
-        </div>
-        <div className="col-6 col-md-4 col-xl">
-          <div className="card card-default h-100">
-            <div className="card-body">
-              <FontAwesomeIcon icon={faPaintBrush} size="lg" />
-              Microsoft Paint
+          <div className="col-6 col-md-4 col-xl">
+            <div className="card card-default h-100">
+              <div className="card-body">
+                <FontAwesomeIcon icon={faPaintBrush} size="lg" />
+                Microsoft Paint
+              </div>
             </div>
           </div>
-        </div>
-        <div className="col-6 col-md-4 col-xl">
-          <div className="card card-default h-100">
-            <div className="card-body">
-              <FontAwesomeIcon icon={faPhotoVideo} size="lg" />
-              Microsoft Photos
+          <div className="col-6 col-md-4 col-xl">
+            <div className="card card-default h-100">
+              <div className="card-body">
+                <FontAwesomeIcon icon={faPhotoVideo} size="lg" />
+                Microsoft Photos
+              </div>
             </div>
           </div>
-        </div>
-        <div className="col-6 col-md-4 col-xl">
-          <div className="card card-default h-100">
-            <div className="card-body">
-              <FontAwesomeIcon icon={faGamepad} size="lg" />
-              Gaming
+          <div className="col-6 col-md-4 col-xl">
+            <div className="card card-default h-100">
+              <div className="card-body">
+                <FontAwesomeIcon icon={faGamepad} size="lg" />
+                Gaming
+              </div>
             </div>
           </div>
-        </div>
-        <div className="col-6 col-md-4 col-xl">
-          <div className="card card-default h-100">
-            <div className="card-body">
-              <FontAwesomeIcon icon={faMusic} size="lg" />
-              Ukulele
+          <div className="col-6 col-md-4 col-xl">
+            <div className="card card-default h-100">
+              <div className="card-body">
+                <FontAwesomeIcon icon={faMusic} size="lg" />
+                Ukulele
+              </div>
             </div>
           </div>
-        </div>
-        <div className="col-6 col-md-4 col-xl">
-          <div className="card card-default h-100">
-            <div className="card-body">
-              <FontAwesomeIcon icon={faFutbol} size="lg" />
-              Football
+          <div className="col-6 col-md-4 col-xl">
+            <div className="card card-default h-100">
+              <div className="card-body">
+                <FontAwesomeIcon icon={faFutbol} size="lg" />
+                Football
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
+    <NextSection href="#contact-me" backgroundColor="#004385" color="white" />
+  </>
 )
 
 export default AboutMe

--- a/src/components/AboutMe/__snapshots__/AboutMe.test.js.snap
+++ b/src/components/AboutMe/__snapshots__/AboutMe.test.js.snap
@@ -1,224 +1,266 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AboutMe renders correctly 1`] = `
-<section
-  id="about-me"
->
-  <div
-    className="container"
+Array [
+  <section
+    id="about-me"
   >
-    <h2>
-      A bit about me
-    </h2>
-    <p>
-      I’m a Software Engineer at
-       
-      <a
-        href="https://madetech.com"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        Made Tech
-      </a>
-      , after graduating from the
-       
-      <a
-        href="https://madetech.com/careers/academy"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        Academy
-      </a>
-       
-      programme in 2019. I build software that makes our customers happy, using Agile practices and techniques such as continuous delivery, test-driven development and pair programming. More recently though, I’ve been using Microsoft Paint and Photos to bring a little silliness into the workplace.
-    </p>
-    <h3>
-      Interests
-    </h3>
     <div
-      className="row"
+      className="container"
     >
+      <h2>
+        A bit about me
+      </h2>
+      <p>
+        I’m a Software Engineer at
+         
+        <a
+          href="https://madetech.com"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Made Tech
+        </a>
+        , after graduating from the
+         
+        <a
+          href="https://madetech.com/careers/academy"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Academy
+        </a>
+         
+        programme in 2019. I build software that makes our customers happy, using Agile practices and techniques such as continuous delivery, test-driven development and pair programming. More recently though, I’ve been using Microsoft Paint and Photos to bring a little silliness into the workplace.
+      </p>
+      <h3>
+        Interests
+      </h3>
       <div
-        className="col-6 col-md-4 col-xl"
+        className="row"
       >
         <div
-          className="card card-default h-100"
+          className="col-6 col-md-4 col-xl"
         >
           <div
-            className="card-body"
+            className="card card-default h-100"
           >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-laugh-squint fa-w-16 fa-lg "
-              data-icon="laugh-squint"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 496 512"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="card-body"
             >
-              <path
-                d="M248 8C111 8 0 119 0 256s111 248 248 248 248-111 248-248S385 8 248 8zm33.8 161.7l80-48c11.6-6.9 24 7.7 15.4 18L343.6 180l33.6 40.3c8.7 10.4-3.9 24.8-15.4 18l-80-48c-7.7-4.7-7.7-15.9 0-20.6zm-163-30c-8.6-10.3 3.8-24.9 15.4-18l80 48c7.8 4.7 7.8 15.9 0 20.6l-80 48c-11.5 6.8-24-7.6-15.4-18l33.6-40.3-33.6-40.3zM398.9 306C390 377 329.4 432 256 432h-16c-73.4 0-134-55-142.9-126-1.2-9.5 6.3-18 15.9-18h270c9.6 0 17.1 8.4 15.9 18z"
-                fill="currentColor"
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-laugh-squint fa-w-16 fa-lg "
+                data-icon="laugh-squint"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
                 style={Object {}}
-              />
-            </svg>
-            Puns
+                viewBox="0 0 496 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M248 8C111 8 0 119 0 256s111 248 248 248 248-111 248-248S385 8 248 8zm33.8 161.7l80-48c11.6-6.9 24 7.7 15.4 18L343.6 180l33.6 40.3c8.7 10.4-3.9 24.8-15.4 18l-80-48c-7.7-4.7-7.7-15.9 0-20.6zm-163-30c-8.6-10.3 3.8-24.9 15.4-18l80 48c7.8 4.7 7.8 15.9 0 20.6l-80 48c-11.5 6.8-24-7.6-15.4-18l33.6-40.3-33.6-40.3zM398.9 306C390 377 329.4 432 256 432h-16c-73.4 0-134-55-142.9-126-1.2-9.5 6.3-18 15.9-18h270c9.6 0 17.1 8.4 15.9 18z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+              Puns
+            </div>
           </div>
         </div>
-      </div>
-      <div
-        className="col-6 col-md-4 col-xl"
-      >
         <div
-          className="card card-default h-100"
+          className="col-6 col-md-4 col-xl"
         >
           <div
-            className="card-body"
+            className="card card-default h-100"
           >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-paint-brush fa-w-16 fa-lg "
-              data-icon="paint-brush"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 512 512"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="card-body"
             >
-              <path
-                d="M167.02 309.34c-40.12 2.58-76.53 17.86-97.19 72.3-2.35 6.21-8 9.98-14.59 9.98-11.11 0-45.46-27.67-55.25-34.35C0 439.62 37.93 512 128 512c75.86 0 128-43.77 128-120.19 0-3.11-.65-6.08-.97-9.13l-88.01-73.34zM457.89 0c-15.16 0-29.37 6.71-40.21 16.45C213.27 199.05 192 203.34 192 257.09c0 13.7 3.25 26.76 8.73 38.7l63.82 53.18c7.21 1.8 14.64 3.03 22.39 3.03 62.11 0 98.11-45.47 211.16-256.46 7.38-14.35 13.9-29.85 13.9-45.99C512 20.64 486 0 457.89 0z"
-                fill="currentColor"
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-paint-brush fa-w-16 fa-lg "
+                data-icon="paint-brush"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
                 style={Object {}}
-              />
-            </svg>
-            Microsoft Paint
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M167.02 309.34c-40.12 2.58-76.53 17.86-97.19 72.3-2.35 6.21-8 9.98-14.59 9.98-11.11 0-45.46-27.67-55.25-34.35C0 439.62 37.93 512 128 512c75.86 0 128-43.77 128-120.19 0-3.11-.65-6.08-.97-9.13l-88.01-73.34zM457.89 0c-15.16 0-29.37 6.71-40.21 16.45C213.27 199.05 192 203.34 192 257.09c0 13.7 3.25 26.76 8.73 38.7l63.82 53.18c7.21 1.8 14.64 3.03 22.39 3.03 62.11 0 98.11-45.47 211.16-256.46 7.38-14.35 13.9-29.85 13.9-45.99C512 20.64 486 0 457.89 0z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+              Microsoft Paint
+            </div>
           </div>
         </div>
-      </div>
-      <div
-        className="col-6 col-md-4 col-xl"
-      >
         <div
-          className="card card-default h-100"
+          className="col-6 col-md-4 col-xl"
         >
           <div
-            className="card-body"
+            className="card card-default h-100"
           >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-photo-video fa-w-20 fa-lg "
-              data-icon="photo-video"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 640 512"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="card-body"
             >
-              <path
-                d="M608 0H160a32 32 0 0 0-32 32v96h160V64h192v320h128a32 32 0 0 0 32-32V32a32 32 0 0 0-32-32zM232 103a9 9 0 0 1-9 9h-30a9 9 0 0 1-9-9V73a9 9 0 0 1 9-9h30a9 9 0 0 1 9 9zm352 208a9 9 0 0 1-9 9h-30a9 9 0 0 1-9-9v-30a9 9 0 0 1 9-9h30a9 9 0 0 1 9 9zm0-104a9 9 0 0 1-9 9h-30a9 9 0 0 1-9-9v-30a9 9 0 0 1 9-9h30a9 9 0 0 1 9 9zm0-104a9 9 0 0 1-9 9h-30a9 9 0 0 1-9-9V73a9 9 0 0 1 9-9h30a9 9 0 0 1 9 9zm-168 57H32a32 32 0 0 0-32 32v288a32 32 0 0 0 32 32h384a32 32 0 0 0 32-32V192a32 32 0 0 0-32-32zM96 224a32 32 0 1 1-32 32 32 32 0 0 1 32-32zm288 224H64v-32l64-64 32 32 128-128 96 96z"
-                fill="currentColor"
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-photo-video fa-w-20 fa-lg "
+                data-icon="photo-video"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
                 style={Object {}}
-              />
-            </svg>
-            Microsoft Photos
+                viewBox="0 0 640 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M608 0H160a32 32 0 0 0-32 32v96h160V64h192v320h128a32 32 0 0 0 32-32V32a32 32 0 0 0-32-32zM232 103a9 9 0 0 1-9 9h-30a9 9 0 0 1-9-9V73a9 9 0 0 1 9-9h30a9 9 0 0 1 9 9zm352 208a9 9 0 0 1-9 9h-30a9 9 0 0 1-9-9v-30a9 9 0 0 1 9-9h30a9 9 0 0 1 9 9zm0-104a9 9 0 0 1-9 9h-30a9 9 0 0 1-9-9v-30a9 9 0 0 1 9-9h30a9 9 0 0 1 9 9zm0-104a9 9 0 0 1-9 9h-30a9 9 0 0 1-9-9V73a9 9 0 0 1 9-9h30a9 9 0 0 1 9 9zm-168 57H32a32 32 0 0 0-32 32v288a32 32 0 0 0 32 32h384a32 32 0 0 0 32-32V192a32 32 0 0 0-32-32zM96 224a32 32 0 1 1-32 32 32 32 0 0 1 32-32zm288 224H64v-32l64-64 32 32 128-128 96 96z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+              Microsoft Photos
+            </div>
           </div>
         </div>
-      </div>
-      <div
-        className="col-6 col-md-4 col-xl"
-      >
         <div
-          className="card card-default h-100"
+          className="col-6 col-md-4 col-xl"
         >
           <div
-            className="card-body"
+            className="card card-default h-100"
           >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-gamepad fa-w-20 fa-lg "
-              data-icon="gamepad"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 640 512"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="card-body"
             >
-              <path
-                d="M480.07 96H160a160 160 0 1 0 114.24 272h91.52A160 160 0 1 0 480.07 96zM248 268a12 12 0 0 1-12 12h-52v52a12 12 0 0 1-12 12h-24a12 12 0 0 1-12-12v-52H84a12 12 0 0 1-12-12v-24a12 12 0 0 1 12-12h52v-52a12 12 0 0 1 12-12h24a12 12 0 0 1 12 12v52h52a12 12 0 0 1 12 12zm216 76a40 40 0 1 1 40-40 40 40 0 0 1-40 40zm64-96a40 40 0 1 1 40-40 40 40 0 0 1-40 40z"
-                fill="currentColor"
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-gamepad fa-w-20 fa-lg "
+                data-icon="gamepad"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
                 style={Object {}}
-              />
-            </svg>
-            Gaming
+                viewBox="0 0 640 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M480.07 96H160a160 160 0 1 0 114.24 272h91.52A160 160 0 1 0 480.07 96zM248 268a12 12 0 0 1-12 12h-52v52a12 12 0 0 1-12 12h-24a12 12 0 0 1-12-12v-52H84a12 12 0 0 1-12-12v-24a12 12 0 0 1 12-12h52v-52a12 12 0 0 1 12-12h24a12 12 0 0 1 12 12v52h52a12 12 0 0 1 12 12zm216 76a40 40 0 1 1 40-40 40 40 0 0 1-40 40zm64-96a40 40 0 1 1 40-40 40 40 0 0 1-40 40z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+              Gaming
+            </div>
           </div>
         </div>
-      </div>
-      <div
-        className="col-6 col-md-4 col-xl"
-      >
         <div
-          className="card card-default h-100"
+          className="col-6 col-md-4 col-xl"
         >
           <div
-            className="card-body"
+            className="card card-default h-100"
           >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-music fa-w-16 fa-lg "
-              data-icon="music"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 512 512"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="card-body"
             >
-              <path
-                d="M470.38 1.51L150.41 96A32 32 0 0 0 128 126.51v261.41A139 139 0 0 0 96 384c-53 0-96 28.66-96 64s43 64 96 64 96-28.66 96-64V214.32l256-75v184.61a138.4 138.4 0 0 0-32-3.93c-53 0-96 28.66-96 64s43 64 96 64 96-28.65 96-64V32a32 32 0 0 0-41.62-30.49z"
-                fill="currentColor"
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-music fa-w-16 fa-lg "
+                data-icon="music"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
                 style={Object {}}
-              />
-            </svg>
-            Ukulele
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M470.38 1.51L150.41 96A32 32 0 0 0 128 126.51v261.41A139 139 0 0 0 96 384c-53 0-96 28.66-96 64s43 64 96 64 96-28.66 96-64V214.32l256-75v184.61a138.4 138.4 0 0 0-32-3.93c-53 0-96 28.66-96 64s43 64 96 64 96-28.65 96-64V32a32 32 0 0 0-41.62-30.49z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+              Ukulele
+            </div>
           </div>
         </div>
-      </div>
-      <div
-        className="col-6 col-md-4 col-xl"
-      >
         <div
-          className="card card-default h-100"
+          className="col-6 col-md-4 col-xl"
         >
           <div
-            className="card-body"
+            className="card card-default h-100"
           >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-futbol fa-w-16 fa-lg "
-              data-icon="futbol"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 512 512"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="card-body"
             >
-              <path
-                d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zm-48 0l-.003-.282-26.064 22.741-62.679-58.5 16.454-84.355 34.303 3.072c-24.889-34.216-60.004-60.089-100.709-73.141l13.651 31.939L256 139l-74.953-41.525 13.651-31.939c-40.631 13.028-75.78 38.87-100.709 73.141l34.565-3.073 16.192 84.355-62.678 58.5-26.064-22.741-.003.282c0 43.015 13.497 83.952 38.472 117.991l7.704-33.897 85.138 10.447 36.301 77.826-29.902 17.786c40.202 13.122 84.29 13.148 124.572 0l-29.902-17.786 36.301-77.826 85.138-10.447 7.704 33.897C442.503 339.952 456 299.015 456 256zm-248.102 69.571l-29.894-91.312L256 177.732l77.996 56.527-29.622 91.312h-96.476z"
-                fill="currentColor"
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-futbol fa-w-16 fa-lg "
+                data-icon="futbol"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
                 style={Object {}}
-              />
-            </svg>
-            Football
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zm-48 0l-.003-.282-26.064 22.741-62.679-58.5 16.454-84.355 34.303 3.072c-24.889-34.216-60.004-60.089-100.709-73.141l13.651 31.939L256 139l-74.953-41.525 13.651-31.939c-40.631 13.028-75.78 38.87-100.709 73.141l34.565-3.073 16.192 84.355-62.678 58.5-26.064-22.741-.003.282c0 43.015 13.497 83.952 38.472 117.991l7.704-33.897 85.138 10.447 36.301 77.826-29.902 17.786c40.202 13.122 84.29 13.148 124.572 0l-29.902-17.786 36.301-77.826 85.138-10.447 7.704 33.897C442.503 339.952 456 299.015 456 256zm-248.102 69.571l-29.894-91.312L256 177.732l77.996 56.527-29.622 91.312h-96.476z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+              Football
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>,
+  <div
+    className="container-fluid next-section"
+    style={
+      Object {
+        "backgroundColor": "#004385",
+      }
+    }
+  >
+    <a
+      className="hvr-wobble-bottom"
+      href="#contact-me"
+      style={
+        Object {
+          "color": "white",
+        }
+      }
+    >
+      <b>
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-angle-down fa-w-10 fa-lg "
+          data-icon="angle-down"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 320 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+        <br />
+        Let's go down
+      </b>
+    </a>
+  </div>,
+]
 `;

--- a/src/components/Landing/Landing.js
+++ b/src/components/Landing/Landing.js
@@ -1,4 +1,5 @@
 import React from "react"
+import NextSection from "../NextSection/NextSection"
 
 import "./Landing.scss"
 
@@ -12,13 +13,14 @@ const Landing = () => (
         </h1>
         <h1>But you can just call me</h1>
         <h1>
-          <mark>
+          <mark className="hvr-buzz">
             <b>Ting</b>
           </mark>
           .
         </h1>
       </div>
     </section>
+    <NextSection href="#about-me" color="black" />
   </>
 )
 

--- a/src/components/Landing/__snapshots__/Landing.test.js.snap
+++ b/src/components/Landing/__snapshots__/Landing.test.js.snap
@@ -1,33 +1,77 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Landing renders correctly 1`] = `
-<section
-  id="landing"
->
-  <div
-    className="container text-center"
+Array [
+  <section
+    id="landing"
   >
-    <h1>
-      Hi there!
-    </h1>
-    <h1>
-      My name is 
-      <b>
-        Wen Ting Wang
-      </b>
-      .
-    </h1>
-    <h1>
-      But you can just call me
-    </h1>
-    <h1>
-      <mark>
+    <div
+      className="container text-center"
+    >
+      <h1>
+        Hi there!
+      </h1>
+      <h1>
+        My name is 
         <b>
-          Ting
+          Wen Ting Wang
         </b>
-      </mark>
-      .
-    </h1>
-  </div>
-</section>
+        .
+      </h1>
+      <h1>
+        But you can just call me
+      </h1>
+      <h1>
+        <mark
+          className="hvr-buzz"
+        >
+          <b>
+            Ting
+          </b>
+        </mark>
+        .
+      </h1>
+    </div>
+  </section>,
+  <div
+    className="container-fluid next-section"
+    style={
+      Object {
+        "backgroundColor": undefined,
+      }
+    }
+  >
+    <a
+      className="hvr-wobble-bottom"
+      href="#about-me"
+      style={
+        Object {
+          "color": "black",
+        }
+      }
+    >
+      <b>
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-angle-down fa-w-10 fa-lg "
+          data-icon="angle-down"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 320 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+        <br />
+        Let's go down
+      </b>
+    </a>
+  </div>,
+]
 `;

--- a/src/components/NextSection/NextSection.js
+++ b/src/components/NextSection/NextSection.js
@@ -1,0 +1,22 @@
+import React from "react"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faAngleDown } from "@fortawesome/free-solid-svg-icons"
+
+import "./NextSection.scss"
+
+const NextSection = ({ href, backgroundColor, color }) => (
+  <div
+    className="container-fluid next-section"
+    style={{ backgroundColor: backgroundColor }}
+  >
+    <a className="hvr-wobble-bottom" href={href} style={{ color: color }}>
+      <b>
+        <FontAwesomeIcon icon={faAngleDown} size="lg" />
+        <br />
+        Let's go down
+      </b>
+    </a>
+  </div>
+)
+
+export default NextSection

--- a/src/components/NextSection/NextSection.scss
+++ b/src/components/NextSection/NextSection.scss
@@ -1,0 +1,23 @@
+.next-section {
+  min-height: 15vh;
+  padding-bottom: 2.5vh;
+  font-family: 'Amatic SC', cursive;
+  text-align: center;
+
+  a { text-decoration: none; }
+}
+
+/* Extra small devices */
+@media only screen and (max-width: 320px) {
+  .next-section { font-size: 1.15em; }
+}
+
+/* Small devices */
+@media only screen and (min-width: 321px) {
+  .next-section { font-size: 1.25em; }
+}
+
+/* Medium devices */
+@media only screen and (min-width: 768px) {
+  .next-section { font-size: 1.75em; }
+}

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,5 +1,6 @@
 @import 'custom';
 @import "~bootstrap/scss/bootstrap";
+@import "~hover.css/css/hover-min";
 
 html { scroll-behavior: smooth; }
 
@@ -9,7 +10,7 @@ body {
 }
 
 section {
-  min-height: 100vh;
+  min-height: 85vh;
   padding: 2.5vh;
   position: relative;
   display: flex;

--- a/test/e2e/user-visits-home-page-spec.js
+++ b/test/e2e/user-visits-home-page-spec.js
@@ -3,7 +3,7 @@ describe("User visits home page", function() {
     whenIVisitTheHomePage()
 
     thenISeeTheWelcomeText()
-    thenISeeABitAboutMe()
+    andISeeABitAboutMe()
     andISeeTheSlogan()
     andISeeTheGitHubLink()
     andISeeTheLinkedInLink()
@@ -18,7 +18,7 @@ describe("User visits home page", function() {
     cy.get("section#landing").should("include.text", "Hi there!")
   }
 
-  function thenISeeABitAboutMe() {
+  function andISeeABitAboutMe() {
     cy.get("section#about-me").should("include.text", "A bit about me")
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7291,6 +7291,11 @@ hosted-git-info@^3.0.2:
   dependencies:
     lru-cache "^5.1.1"
 
+hover.css@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/hover.css/-/hover.css-2.3.2.tgz#f07193d9c7409d4e395134d3b2215b99eb55e0d3"
+  integrity sha1-8HGT2cdAnU45UTTTsiFbmetV4NM=
+
 hpack.js@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2"


### PR DESCRIPTION
## Context

As each section takes up a whole height of the screen, it may not be immediately apparent that there is more on the page.

## Changes proposed in this pull request

This PR adds a link at the end of each section to go down a section.

### Screenshots

| Before | After |
|--------|-------|
|![image](https://user-images.githubusercontent.com/42817036/76706707-96afcd80-66e1-11ea-9fc6-a1834b386efc.png)|![image](https://user-images.githubusercontent.com/42817036/76706699-83046700-66e1-11ea-8c3b-cf26f0a73841.png)| 

## Guidance to review

N/A

## Link to Trello card

https://trello.com/c/OFrjNyrp/56-i-want-to-add-an-about-me-section-to-my-personal-website-so-that-people-know-who-i-am